### PR TITLE
Workaround for dispatcher servlets being loaded before repo was ready

### DIFF
--- a/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryBootstrapFinishedListener.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryBootstrapFinishedListener.java
@@ -1,0 +1,10 @@
+package com.gradecak.alfresco.mvc.webscript;
+
+/**
+ * Created by jancalve on 20/04/16.
+ */
+public interface RepositoryBootstrapFinishedListener {
+
+  void onBootstrapFinishedEvent();
+
+}

--- a/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryBootstrapListenerManager.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryBootstrapListenerManager.java
@@ -1,0 +1,25 @@
+package com.gradecak.alfresco.mvc.webscript;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by jancalve on 20/04/16.
+ */
+public class RepositoryBootstrapListenerManager {
+
+  private List<RepositoryBootstrapFinishedListener> listeners = new ArrayList<RepositoryBootstrapFinishedListener>();
+
+  public void addListener(RepositoryBootstrapFinishedListener listener) {
+    System.out.println("Adding listener..");
+    listeners.add(listener);
+  }
+
+  public void notifyListeners() {
+    System.out.println("Notifying listeners..");
+    for (RepositoryBootstrapFinishedListener listener : listeners) {
+      listener.onBootstrapFinishedEvent();
+    }
+  }
+
+}

--- a/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryFinishedBootstrapBean.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/webscript/RepositoryFinishedBootstrapBean.java
@@ -1,0 +1,24 @@
+package com.gradecak.alfresco.mvc.webscript;
+
+import org.alfresco.repo.admin.RepositoryEndBootstrapBean;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Created by jancalve on 20/04/16.
+ */
+public class RepositoryFinishedBootstrapBean extends RepositoryEndBootstrapBean {
+
+  private RepositoryBootstrapListenerManager repositoryBootstrapListenerManager;
+
+  @Override
+  protected void onBootstrap(ApplicationEvent event) {
+    repositoryBootstrapListenerManager.notifyListeners();
+  }
+
+  public void setRepositoryBootstrapListenerManager(RepositoryBootstrapListenerManager repositoryBootstrapListenerManager) {
+    this.repositoryBootstrapListenerManager = repositoryBootstrapListenerManager;
+  }
+
+
+
+}


### PR DESCRIPTION
This is a workaround (which I've tested with success on a Alfresco 5.1 MT environment) I did by adding a listener to the RepositoryEndBootstrapBean, which notifies the DispatcherWebscript that it can start wiring up the WebApplicationContext.

With module-context.xml looking like:
`
<beans>
    <bean id="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"
          class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
          parent="webscript">
        <property name="contextConfigLocation"
                  value="classpath:alfresco/module/ph-alfresco-ext/context/dispatcher/servlet-context.xml"/>

```
</bean>

<bean id="repositoryBootstrapListenerManager"
      class="com.gradecak.alfresco.mvc.webscript.RepositoryBootstrapListenerManager">
</bean>

<bean id="repositoryFinishedBootstrapBean"
      class="com.gradecak.alfresco.mvc.webscript.RepositoryFinishedBootstrapBean"
      parent="repositoryEndBootstrapBean" >
    <property name="repositoryState">
        <ref bean="repositoryState"/>
    </property>
    <property name="repositoryBootstrapListenerManager">
        <ref bean="repositoryBootstrapListenerManager"/>
    </property>

</bean>

<bean id="webscript.no.joint.darwin.darwin-web-controllers.dispatch.post"
      class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
      parent="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"/>

<bean id="webscript.no.joint.darwin.darwin-web-controllers.dispatch.put"
      class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
      parent="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"/>

<bean id="webscript.no.joint.darwin.darwin-web-controllers.dispatch.delete"
      class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
      parent="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"/>

<bean id="webscript.no.joint.darwin.darwin-web-controllers.unauthenticated.post"
      class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
      parent="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"/>

<bean id="webscript.no.joint.darwin.darwin-web-controllers.unauthenticated.get"
      class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript"
      parent="webscript.no.joint.darwin.darwin-web-controllers.dispatch.get"/>
```

</beans>`
