### PR TITLE
Changes to DispatcherWebscript so it can bootstrap only on repositoryEndBootstrapBean

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ as in a medium sized application that becomes unmaintainable. That is why I wrot
 This small library enables the usage of Spring @MVC within Alfresco. Instead of writing webscripts and all the glue configuration that goes with that, you can simply write Springframework 
 Controllers, Services/Components, ... with Spring annotations.
 
-This library is deployed as an alfresco module (jar packaged) and offers some out of the box configurations for webscript bindings. The entry endpoint is bydefault /mvc only if the DispatcherWebscript
-is configured as follows.
+This library is deployed as an alfresco module (jar packaged) and offers some out of the box configurations for webscript bindings. The entry endpoint is bydefault /mvc if the library is bootstrap
+in the following way:
 
 
 ```
-<bean id="webscript.alfresco-mvc.mvc.post" class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript" parent="webscript">
-    <property name="contextConfigLocation" value="classpath:alfresco/module/YOUR-MODULE/context/servlet-context.xml" />
-</bean>
+ <bean id="alfrescoMvcBean" class="com.gradecak.alfresco.mvc.bootstrap.MVCBootstrapper" parent="repositoryEndBootstrapBean">
+    <property name="contextConfigLocation" value="classpath:alfresco/module/efiles-common-repo/context/servlet-context.xml" />
+  </bean>
+
+ <alias name="mvc.dispatcherWebscript" alias="webscript.alfresco-mvc.mvc.get"/>
+
 ```
 
 Surely, you can configure any other webscript descriptor.
@@ -125,7 +128,7 @@ There is more things to add, so TBC ...
 Alfresco versions
 ----
 - Works on Enterprise as well as on community.
-- Tested with Alfresco Community 3.4.d, 4.0.x, 4.2.x, 5.0.a, 5.0.d, 5.1.e, 5.2.f
+- Tested with Alfresco Community 3.4.d, 4.0.x, 4.2.x, 5.0.a, 5.0.d, 5.1.e, 5.2.f, 5.2.g
 - Tested with Alfresco Enterprise 3.4.5, 4.1.5, 4.2.1, 5.1.x, 5.2.x
 
 Distribution (TODO as it is not yet inline with the latests @MVC library)

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,56 @@
       <artifactId>alfresco-repository</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>3.0.5.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${alfresco.groupId}</groupId>
+      <artifactId>alfresco-repository</artifactId>
+      <version>${alfresco.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.alfresco.surf</groupId>
+      <artifactId>spring-webscripts</artifactId>
+      <version>6.4</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-remote-api</artifactId>
+      <version>${alfresco.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>3.2.10.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/gradecak/alfresco/mvc/bootstrap/MVCBootstrapper.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/bootstrap/MVCBootstrapper.java
@@ -1,0 +1,52 @@
+package com.gradecak.alfresco.mvc.bootstrap;
+
+
+import com.gradecak.alfresco.mvc.webscript.DispatcherWebscript;
+import org.alfresco.error.AlfrescoRuntimeException;
+import org.alfresco.repo.admin.RepositoryEndBootstrapBean;
+import org.alfresco.repo.admin.RepositoryState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.web.context.ServletContextAware;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ * Created by pereirat on 11/10/2017.
+ */
+public class MVCBootstrapper extends RepositoryEndBootstrapBean implements ServletContextAware {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DispatcherWebscript.class);
+
+  private DispatcherWebscript dispatcherWebscript;
+  private ServletContext servletContext;
+  private String contextConfigLocation;
+
+  @Override
+  public void onBootstrap(ApplicationEvent event) {
+
+    LOGGER.info("Starting Alfresco MVC...");
+
+    RepositoryState repositoryState = getRepositoryState();
+    if(repositoryState.isBootstrapping())
+      throw new AlfrescoRuntimeException("Alfresco MVC cannot auto proxy while the repository is bootstrapping");
+
+    dispatcherWebscript = (DispatcherWebscript) getApplicationContext().getBean("mvc.dispatcherWebscript");
+    try {
+      dispatcherWebscript.initialize(getApplicationContext(), servletContext, contextConfigLocation);
+    } catch(ServletException e) {
+      LOGGER.info("Error initializing Alfresco MVC dispatcher webscript");
+    }
+  }
+
+  @Override
+  public void setServletContext(ServletContext servletContext) {
+    this.servletContext = servletContext;
+  }
+
+  public void setContextConfigLocation(String contextConfigLocation) {
+    this.contextConfigLocation = contextConfigLocation;
+  }
+}

--- a/src/main/java/com/gradecak/alfresco/mvc/bootstrap/MVCBootstrapper.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/bootstrap/MVCBootstrapper.java
@@ -14,7 +14,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 /**
- * Created by pereirat on 11/10/2017.
+ * Created by mauro1855 on 11/10/2017.
  */
 public class MVCBootstrapper extends RepositoryEndBootstrapBean implements ServletContextAware {
 

--- a/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2PostProcessor.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2PostProcessor.java
@@ -17,27 +17,28 @@
 package com.gradecak.alfresco.mvc.jackson;
 
 import java.text.SimpleDateFormat;
+import java.util.List;
 
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.namespace.QName;
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.module.SimpleModule;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.StringUtils;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
-/**
- * @deprecated use {@link Jackson2PostProcessor}
- */
-public class JacksonPostProcessor implements BeanPostProcessor {
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Jackson2PostProcessor implements BeanPostProcessor {
   public static final String DEFAULT_JSON_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
   @Autowired
+  @Qualifier("ServiceRegistry")
   private ServiceRegistry serviceRegistry;
 
   private String dateFormat;
@@ -47,17 +48,17 @@ public class JacksonPostProcessor implements BeanPostProcessor {
   }
 
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-    if (bean instanceof AnnotationMethodHandlerAdapter) {
-      AnnotationMethodHandlerAdapter adapter = (AnnotationMethodHandlerAdapter) bean;
-      HttpMessageConverter<?>[] converters = adapter.getMessageConverters();
+    if (bean instanceof RequestMappingHandlerAdapter) {
+      RequestMappingHandlerAdapter adapter = (RequestMappingHandlerAdapter) bean;
+      List<HttpMessageConverter<?>> converters = adapter.getMessageConverters();
       for (HttpMessageConverter<?> converter : converters) {
-        if (converter instanceof MappingJacksonHttpMessageConverter) {
-          MappingJacksonHttpMessageConverter jsonConverter = (MappingJacksonHttpMessageConverter) converter;
+        if (converter instanceof MappingJackson2HttpMessageConverter) {
+          MappingJackson2HttpMessageConverter jsonConverter = (MappingJackson2HttpMessageConverter) converter;
 
           ObjectMapper objectMapper = new ObjectMapper();
-          SimpleModule module = new SimpleModule("Alfresco MVC Module", new Version(1, 0, 0, null));
-          module.addSerializer(QName.class, new QnameSerializer(serviceRegistry));
-          module.addDeserializer(QName.class, new QnameDeserializer(serviceRegistry));
+          SimpleModule module = new SimpleModule("Alfresco MVC Module", new Version(1, 0, 0, null, null, null));
+          module.addSerializer(QName.class, new Jackson2QnameSerializer(serviceRegistry));
+          module.addDeserializer(QName.class, new Jackson2QnameDeserializer(serviceRegistry));
 
           objectMapper.setDateFormat(new SimpleDateFormat(getDateFormat()));
           objectMapper.registerModule(module);

--- a/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2QnameDeserializer.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2QnameDeserializer.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.jackson;
+
+import java.io.IOException;
+
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.namespace.QName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class Jackson2QnameDeserializer extends JsonDeserializer<QName>implements Converter<String, QName> {
+
+  private ServiceRegistry serviceRegistry;
+
+  @Autowired
+  public Jackson2QnameDeserializer(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public QName deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+
+    String qname = jp.getText();
+    if (StringUtils.hasText(qname)) {
+      return QName.createQName(qname, serviceRegistry.getNamespaceService());
+    }
+
+    throw ctxt.mappingException("Expected a valid QName string representation");
+  }
+
+  @Override
+  public QName convert(String qname) {
+    if(!StringUtils.hasText(qname)) {
+      return null;
+    }
+    return QName.createQName(qname, serviceRegistry.getNamespaceService());
+  }
+
+}

--- a/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2QnameSerializer.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/jackson/Jackson2QnameSerializer.java
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-package com.gradecak.alfresco.mvc.converter;
+package com.gradecak.alfresco.mvc.jackson;
 
 import java.io.IOException;
 
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.namespace.QName;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
 
-public class QnameSerializer extends JsonSerializer<QName> {
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class Jackson2QnameSerializer extends JsonSerializer<QName> {
 
   private ServiceRegistry serviceRegistry;
 
-  public QnameSerializer(ServiceRegistry serviceRegistry) {
+  public Jackson2QnameSerializer(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 

--- a/src/main/java/com/gradecak/alfresco/mvc/jackson/QnameDeserializer.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/jackson/QnameDeserializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.gradecak.alfresco.mvc.converter;
+package com.gradecak.alfresco.mvc.jackson;
 
 import java.io.IOException;
 
@@ -26,6 +26,9 @@ import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 import org.springframework.util.StringUtils;
 
+/**
+ * @deprecated
+ */
 public class QnameDeserializer extends JsonDeserializer<QName> {
 
   private ServiceRegistry serviceRegistry;

--- a/src/main/java/com/gradecak/alfresco/mvc/jackson/QnameSerializer.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/jackson/QnameSerializer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.jackson;
+
+import java.io.IOException;
+
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.namespace.QName;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+
+/**
+ * @deprecated
+ */
+public class QnameSerializer extends JsonSerializer<QName> {
+
+  private ServiceRegistry serviceRegistry;
+
+  public QnameSerializer(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public void serialize(QName value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+    String prefixString = value.toPrefixString(serviceRegistry.getNamespaceService());
+    jgen.writeString(prefixString);
+  }
+
+  @Override
+  public Class<QName> handledType() {
+    return QName.class;
+  }
+
+}

--- a/src/main/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscript.java
+++ b/src/main/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscript.java
@@ -25,22 +25,20 @@ import java.util.regex.Pattern;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 import org.springframework.extensions.webscripts.WrappingWebScriptResponse;
 import org.springframework.extensions.webscripts.servlet.WebScriptServletRequest;
 import org.springframework.extensions.webscripts.servlet.WebScriptServletResponse;
-import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.util.JavaScriptUtils;
@@ -48,13 +46,11 @@ import org.springframework.web.util.NestedServletException;
 
 import com.gradecak.alfresco.mvc.ResponseMapBuilder;
 
-public class DispatcherWebscript extends AbstractWebScript implements ServletContextAware, ApplicationContextAware, InitializingBean {
+public class DispatcherWebscript extends AbstractWebScript {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DispatcherWebscript.class);
 
   private DispatcherServlet s;
-  private String contextConfigLocation;
-  private ApplicationContext applicationContext;
   private ServletContext servletContext;
 
   public void execute(WebScriptRequest req, WebScriptResponse res) throws IOException {
@@ -75,7 +71,6 @@ public class DispatcherWebscript extends AbstractWebScript implements ServletCon
     try {
       s.service(wrapper, sr);
     } catch (Throwable e) {
-      LOGGER.error("MVC could not proceed", e);
       convertExceptionToJson(e, sr);
     }
 
@@ -101,7 +96,9 @@ public class DispatcherWebscript extends AbstractWebScript implements ServletCon
     objectMapper.writeValue(res.getOutputStream(), builder.build());
   }
 
-  public void afterPropertiesSet() throws Exception {
+  public void initialize(final ApplicationContext applicationContext, ServletContext servletContext, String contextConfigLocation) throws ServletException {
+
+    setServletContext(servletContext);
 
     s = new DispatcherServlet() {
 
@@ -120,14 +117,6 @@ public class DispatcherWebscript extends AbstractWebScript implements ServletCon
 
     s.setContextConfigLocation(contextConfigLocation);
     s.init(new DelegatingServletConfig());
-  }
-
-  public void setContextConfigLocation(String contextConfigLocation) {
-    this.contextConfigLocation = contextConfigLocation;
-  }
-
-  public void setApplicationContext(ApplicationContext applicationContext) {
-    this.applicationContext = applicationContext;
   }
 
   public void setServletContext(ServletContext servletContext) {

--- a/src/main/resources/alfresco/module/mvc/context/aop-context.xml
+++ b/src/main/resources/alfresco/module/mvc/context/aop-context.xml
@@ -52,4 +52,6 @@
     <property name="serviceRegistry" ref="ServiceRegistry" />
   </bean>
 
+  <bean id="mvc.dispatcherWebscript" class="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript" parent="webscript"/>
+
 </beans>

--- a/src/test/java/com/gradecak/alfresco/mvc/aop/AuthenticationTest.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/aop/AuthenticationTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.aop;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.alfresco.repo.security.authentication.AuthenticationException;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.security.AuthorityService;
+import org.alfresco.service.cmr.security.MutableAuthenticationService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.gradecak.alfresco.mvc.service.AuthenticationService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(value = { "classpath:test-aop-context.xml" })
+public class AuthenticationTest {
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Mock
+  private MutableAuthenticationService authenticationService;
+
+  @Mock
+  private AuthorityService authorityService;
+
+  @Mock
+  private NodeService nodeService;
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @Autowired
+  private AuthenticationService service;
+
+  private AuthenticationUtil util = new AuthenticationUtil();
+  private NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "aaa");
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    when(serviceRegistry.getAuthenticationService()).thenReturn(authenticationService);
+    when(serviceRegistry.getAuthorityService()).thenReturn(authorityService);
+    when(serviceRegistry.getNodeService()).thenReturn(nodeService);
+    when(authenticationService.getCurrentTicket()).thenReturn("ticket");
+
+    when(authorityService.hasGuestAuthority()).thenReturn(true);
+    when(authorityService.hasAdminAuthority()).thenReturn(false);
+
+    util.afterPropertiesSet();
+
+    assertTrue(AopUtils.isAopProxy(service));
+    
+    AuthenticationUtil.clearCurrentSecurityContext();
+  }
+
+  @Test
+  public void authentifiedAsGuest_noneAuthenticaionRequired() {
+    service.getNamePropertyAsNone(nodeRef);
+  }
+
+  @Test
+  public void authentifiedAsGuest_atLeastUserAuthenticationRequired() {
+
+    exception.expect(AuthenticationException.class);
+    service.getNamePropertyAsUser(nodeRef);
+  }
+  
+  @Test
+  public void authentifiedAsGuest_atLeastDefaultUserAuthenticationRequired() {
+
+    exception.expect(AuthenticationException.class);
+    service.getNamePropertyAsDefault(nodeRef);
+  }
+
+
+  @Test
+  public void authentifiedAsUser_atLeastUserAuthenticationRequired() {
+
+    when(authorityService.hasGuestAuthority()).thenReturn(false);
+
+    service.getNamePropertyAsUser(nodeRef);
+  }
+
+  @Test
+  public void authentifiedAsUser_atLeastAdminAuthenticationRequired() {
+
+    when(authorityService.hasGuestAuthority()).thenReturn(false);
+
+    exception.expect(AuthenticationException.class);
+    service.getNamePropertyAsAdmin(nodeRef);
+  }
+
+  @Test
+  public void authentifiedAsAdmin_atLeastAdminAuthenticationRequired() {
+
+    when(authorityService.hasAdminAuthority()).thenReturn(true);
+
+    service.getNamePropertyAsAdmin(nodeRef);
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/aop/RunAsTest.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/aop/RunAsTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.aop;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.security.AuthorityService;
+import org.alfresco.service.cmr.security.MutableAuthenticationService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.gradecak.alfresco.mvc.service.RunAsService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(value = { "classpath:test-aop-context.xml" })
+public class RunAsTest {
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Mock
+  private MutableAuthenticationService authenticationService;
+
+  @Mock
+  private AuthorityService authorityService;
+
+  @Mock
+  private NodeService nodeService;
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @Autowired
+  private RunAsService service;
+
+  private AuthenticationUtil util = new AuthenticationUtil();
+  private NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "aaa");
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    when(serviceRegistry.getAuthenticationService()).thenReturn(authenticationService);
+    when(serviceRegistry.getAuthorityService()).thenReturn(authorityService);
+    when(serviceRegistry.getNodeService()).thenReturn(nodeService);
+    when(authenticationService.getCurrentTicket()).thenReturn("ticket");
+
+    when(authorityService.hasGuestAuthority()).thenReturn(true);
+    when(authorityService.hasAdminAuthority()).thenReturn(false);
+
+    util.afterPropertiesSet();
+
+    assertTrue(AopUtils.isAopProxy(service));
+    AuthenticationUtil.clearCurrentSecurityContext();
+  }
+
+  @Test
+  public void noAutehntication_runAsSystem() {    
+    service.getNamePropertyAsSystem(nodeRef);
+    
+    Assert.assertNull(AuthenticationUtil.getRunAsUser());
+    Assert.assertNull(AuthenticationUtil.getFullyAuthenticatedUser());
+  }
+  
+  @Test
+  public void authentifiedAsTest_runAsUser() {
+
+    AuthenticationUtil.setFullyAuthenticatedUser("test");
+    when(authorityService.hasGuestAuthority()).thenReturn(false);
+    service.getNamePropertyAsUser(nodeRef);
+    Assert.assertEquals("test", AuthenticationUtil.getRunAsUser());
+    Assert.assertEquals("test", AuthenticationUtil.getFullyAuthenticatedUser());
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/aop/TransactionalTest.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/aop/TransactionalTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.aop;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.transaction.SystemException;
+
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.transaction.TransactionService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.gradecak.alfresco.mvc.service.TransactionalService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(value = { "classpath:test-aop-context.xml" })
+public class TransactionalTest {
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Mock
+  private TransactionService transactionService;
+  
+  @Mock
+  private RetryingTransactionHelper retryingTransactionHelper;
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @Autowired
+  private TransactionalService service;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    when(serviceRegistry.getTransactionService()).thenReturn(transactionService);
+    when(serviceRegistry.getTransactionService().getRetryingTransactionHelper()).thenReturn(retryingTransactionHelper);
+
+    assertTrue(AopUtils.isAopProxy(service));
+  }
+  
+  @Test
+  @SuppressWarnings("unchecked")
+  public void txRWriteWithPropagationRequired() throws SystemException {
+    service.transactionWriteWithoutPropagation();
+    verify(retryingTransactionHelper).doInTransaction(any(RetryingTransactionCallback.class), eq(false), eq(false));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void txReadOnlyWithPropagationRequired() throws SystemException {
+    service.transactioReadOnlyWithPropagationRequired();
+    verify(retryingTransactionHelper).doInTransaction(any(RetryingTransactionCallback.class), eq(true), eq(false));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void txReadOnlyWithPropagationRequiresNew() throws SystemException {
+    service.transactioReadOnlyWithPropagationRequiresNew();
+    verify(retryingTransactionHelper).doInTransaction(any(RetryingTransactionCallback.class), eq(true), eq(true));
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/controller/TestController.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/controller/TestController.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.controller;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.gradecak.alfresco.mvc.ResponseMapBuilder;
+
+@Controller
+@RequestMapping("/test")
+public class TestController {
+
+
+  @RequestMapping(value = "/get", method = { RequestMethod.GET })
+  @ResponseBody
+  public Map<String, Object> get(@RequestParam String id) {
+    return ResponseMapBuilder.createResponseMap(id, true).build();
+  }
+  
+  @RequestMapping(value = "/post", method = { RequestMethod.POST })
+  @ResponseBody
+  public Map<String, Object> post(@RequestParam String id) {
+    return ResponseMapBuilder.createResponseMap(id, true).build();
+  }
+  
+  @RequestMapping(value = "/post2", method = { RequestMethod.POST })
+  @ResponseBody
+  public Map<String, Object> post() {
+    return ResponseMapBuilder.createSuccessResponseMap().build();
+  }
+  
+  @RequestMapping(value = "/exception", method = { RequestMethod.GET })
+  @ResponseBody
+  public Map<String, Object> exception(@RequestParam String id) {
+    throw new RuntimeException("test exception");
+  }
+  
+  @RequestMapping(value = "/body", method = { RequestMethod.POST })
+  @ResponseBody
+  public Map<String, Object> post(@RequestBody Map<String, Object> body ) {
+    return ResponseMapBuilder.createResponseMap(body, true).build();
+  }
+
+  @RequestMapping(value = "/delete", method = { RequestMethod.DELETE, RequestMethod.PUT })
+  @ResponseBody
+  public Map<String, Object> delete() {
+    return ResponseMapBuilder.createSuccessResponseMap().build();
+  }  
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/service/AuthenticationService.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/service/AuthenticationService.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.service;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.gradecak.alfresco.mvc.annotation.AlfrescoAuthentication;
+import com.gradecak.alfresco.mvc.annotation.AuthenticationType;
+
+@Service
+public class AuthenticationService {
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @AlfrescoAuthentication
+  public String getNamePropertyAsDefault(final NodeRef nodeRef) {
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoAuthentication(AuthenticationType.USER)
+  public String getNamePropertyAsUser(final NodeRef nodeRef) {
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoAuthentication(AuthenticationType.ADMIN)
+  public String getNamePropertyAsAdmin(final NodeRef nodeRef) {
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoAuthentication(AuthenticationType.NONE)
+  public String getNamePropertyAsNone(final NodeRef nodeRef) {
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/service/RunAsService.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/service/RunAsService.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.service;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.junit.Assert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.gradecak.alfresco.mvc.annotation.AlfrescoRunAs;
+
+@Service
+public class RunAsService {
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @AlfrescoRunAs("user")
+  public String getNamePropertyAsUser(final NodeRef nodeRef) {
+    Assert.assertEquals("user", AuthenticationUtil.getRunAsUser());
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoRunAs(AuthenticationUtil.SYSTEM_USER_NAME)
+  public String getNamePropertyAsSystem(final NodeRef nodeRef) {
+    Assert.assertEquals(AuthenticationUtil.SYSTEM_USER_NAME, AuthenticationUtil.getRunAsUser());
+    return (String) serviceRegistry.getNodeService().getProperty(nodeRef, ContentModel.PROP_NAME);
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/service/TransactionalService.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/service/TransactionalService.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.service;
+
+import javax.transaction.SystemException;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.service.ServiceRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+
+import com.gradecak.alfresco.mvc.annotation.AlfrescoTransaction;
+
+@Service
+public class TransactionalService {
+
+  @Autowired
+  private ServiceRegistry serviceRegistry;
+
+  @AlfrescoTransaction
+  public String transactionWriteWithoutPropagation() {
+    return (String) serviceRegistry.getNodeService().getProperty(null, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoTransaction(readOnly=true)
+  public String transactioReadOnlyWithPropagationRequired() throws SystemException {
+    return (String) serviceRegistry.getNodeService().getProperty(null, ContentModel.PROP_NAME);
+  }
+  
+  @AlfrescoTransaction(readOnly=true, propagation=Propagation.REQUIRES_NEW)
+  public String transactioReadOnlyWithPropagationRequiresNew() throws SystemException {
+    return (String) serviceRegistry.getNodeService().getProperty(null, ContentModel.PROP_NAME);
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscriptTest.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscriptTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.webscript;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+
+import com.google.common.collect.ImmutableMap;
+import com.gradecak.alfresco.mvc.webscript.mock.MockWebscript;
+import com.gradecak.alfresco.mvc.webscript.mock.MockWebscriptBuilder;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+@ContextConfiguration(value = { "classpath:test-webscriptdispatcher-context.xml"})
+public class DispatcherWebscriptTest {
+
+  private @Spy DispatcherWebscript webScript;
+
+  private MockWebscript mockWebscript;
+
+  @Before
+  public void before() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    String testContextLocation = "classpath:test-webscriptdispatcher-context.xml";
+    webScript.initialize(mock(ApplicationContext.class), new MockServletContext(), testContextLocation);
+
+    mockWebscript = MockWebscriptBuilder.singleWebscript(webScript);
+  }
+
+  @Test
+  public void requestGet_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withParameters(ImmutableMap.of("id", "testId")).withControllerMapping("test/get").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"data\":\"testId\",\"total\":1,\"success\":true}", res.getContentAsString());
+  }
+
+  @Test
+  public void requestPost_withParams_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withParameters(ImmutableMap.of("id", "testId")).withControllerMapping("test/post").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"data\":\"testId\",\"total\":1,\"success\":true}", res.getContentAsString());
+  }
+  
+  @Test
+  public void requestPost_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withControllerMapping("test/post2").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"success\":true}", res.getContentAsString());
+  }
+
+  @Test
+  public void requestPost_withBody_response400() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withControllerMapping("test/body").execute();
+    Assert.assertTrue(res.getStatus() == 400);
+  }
+
+  @Test
+  public void requestPost_withBody_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withBody(ImmutableMap.of("id", "testId")).withControllerMapping("test/body").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"data\":{\"id\":\"testId\"},\"total\":1,\"success\":true}", res.getContentAsString());
+  }
+
+  @Test
+  public void requestGet_wrongControllerMapping_response404() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withParameters(ImmutableMap.of("id", "testId")).withControllerMapping("test/wrong").execute();
+    Assert.assertTrue(res.getStatus() == 404);
+  }
+
+  @Test
+  public void requestPost_toGetMethod() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withParameters(ImmutableMap.of("id", "testId")).withControllerMapping("test/get").execute();
+    Assert.assertTrue(res.getStatus() == 405);
+    Assert.assertEquals("Request method 'POST' not supported", res.getErrorMessage());
+  }
+  
+  @Test
+  public void requestDelete_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withMethod(HttpMethod.DELETE).withControllerMapping("test/delete").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"success\":true}", res.getContentAsString());
+  }
+  
+  @Test
+  public void requestPut_responseOk() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withMethod(HttpMethod.PUT).withControllerMapping("test/delete").execute();
+    Assert.assertTrue(res.getStatus() == 200);
+    Assert.assertEquals("{\"success\":true}", res.getContentAsString());
+  }
+  
+  @Test
+  public void requestHead_response405() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withPostRequest().withMethod(HttpMethod.HEAD).withControllerMapping("test/delete").execute();
+    Assert.assertTrue(res.getStatus() == 405);
+  }
+
+  @Test
+  public void requestGet_responseException() throws Exception {
+    MockHttpServletResponse res = mockWebscript.withParameters(ImmutableMap.of("id", "testId")).withControllerMapping("test/exception").execute();
+    Assert.assertTrue(res.getStatus() == HttpServletResponse.SC_BAD_REQUEST);
+    Assert.assertEquals("{\"success\":false,\"event\":\"exception\",\"exception\":\"org.springframework.web.util.NestedServletException\","
+        + "\"message\":\"Request processing failed; nested exception is java.lang.RuntimeException: test exception\","
+        + "\"cause\":\"java.lang.RuntimeException\",\"causeMessage\":\"test exception\"}", res.getContentAsString());
+  }
+
+  // TODO add file upload test
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebScriptResponse.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebScriptResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.webscript.mock;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.extensions.webscripts.Runtime;
+import org.springframework.extensions.webscripts.servlet.WebScriptServletResponse;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class MockWebScriptResponse extends WebScriptServletResponse{
+  
+  private MockHttpServletResponse mockHttpServletResponse;
+  
+  private MockWebScriptResponse(Runtime mockedRuntime, MockHttpServletResponse mockHttpServletResponse) {
+    super(mockedRuntime, mockHttpServletResponse);
+    this.mockHttpServletResponse = mockHttpServletResponse;
+  }
+  
+  public MockHttpServletResponse getMockHttpServletResponse() {
+    return mockHttpServletResponse;
+  }
+
+  static public MockWebScriptResponse createMockWebScriptResponse() {
+    return new MockWebScriptResponse(mock(Runtime.class), new MockHttpServletResponse());
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscript.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscript.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.webscript.mock;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.extensions.webscripts.AbstractWebScript;
+import org.springframework.extensions.webscripts.Container;
+import org.springframework.extensions.webscripts.Description;
+import org.springframework.extensions.webscripts.Description.RequiredCache;
+import org.springframework.extensions.webscripts.ScriptProcessorRegistry;
+import org.springframework.extensions.webscripts.SearchPath;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.google.common.base.Throwables;
+
+public class MockWebscript {
+
+  private AbstractWebScript webScript;
+  private HttpMethod method = HttpMethod.GET;
+  private Map<String, String> parameters;
+  private Map<String, String> body;
+  private String webscriptUrl = "/service/mvc/";
+  private String controllerMapping;
+  private Container container = getMockedContainer();
+  private Description description = getMockedDescription();
+
+  public MockWebscript(final AbstractWebScript webScript) {
+    this.webScript = webScript;
+  }
+
+  public MockWebscript withGetRequest() {
+    return withMethod(HttpMethod.GET);
+  }
+
+  public MockWebscript withPostRequest() {
+    return withMethod(HttpMethod.POST);
+  }
+
+  public MockWebscript withMethod(final HttpMethod method) {
+    this.method = method;
+    return this;
+  }
+
+  public MockWebscript withParameters(final Map<String, String> parameters) {
+    this.parameters = parameters;
+    return this;
+  }
+  
+  public MockWebscript withBody(final Map<String, String> body) {
+    this.body = body;
+    return this;
+  }
+
+  public MockWebscript withControllerMapping(final String controllerMapping) {
+    this.controllerMapping = controllerMapping;
+    return this;
+  }
+
+  public MockWebscript withUrl(final String webscriptUrl) {
+    this.webscriptUrl = webscriptUrl;
+    return this;
+  }
+
+  public MockWebscript withContainer(final Container container) {
+    this.container = container;
+    return this;
+  }
+
+  public MockWebscript withDescription(final Description description) {
+    this.description = description;
+    return this;
+  }
+
+  // public MockWebscript withContent(final String content) {
+  // this.content = content;
+  // return this;
+  // }
+
+  public MockHttpServletResponse execute() {
+    return doRequest(webScript, container, description, method.name(), parameters, body, webscriptUrl, controllerMapping);
+  }
+
+  private MockHttpServletResponse doRequest(AbstractWebScript webScript, Container container, Description description, String method, Map<String, String> parameters, Map<String, String> body, String webscriptUrl,
+      String controllerMapping) {
+    webScript.init(container, description);
+
+    MockWebScriptResponse mockedResponse = MockWebScriptResponse.createMockWebScriptResponse();
+    try {
+      webScript.execute(MockWebscriptServletRequest.createMockWebscriptServletRequest(webScript, method, webscriptUrl, controllerMapping, parameters, body), mockedResponse);
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
+
+    return mockedResponse.getMockHttpServletResponse();
+  }
+
+  static private Container getMockedContainer() {
+    ScriptProcessorRegistry mockedScriptProcessorRegistry = mock(ScriptProcessorRegistry.class);
+    doReturn(null).when(mockedScriptProcessorRegistry).findValidScriptPath(anyString());
+
+    Container mockedContainer = mock(Container.class);
+    SearchPath mockedSearchPath = mock(SearchPath.class);
+    try {
+      doReturn(false).when(mockedSearchPath).hasDocument(anyString());
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
+    doReturn(mockedSearchPath).when(mockedContainer).getSearchPath();
+
+    return mockedContainer;
+  }
+
+  static private Description getMockedDescription() {
+    Description mockedDescription = mock(Description.class);
+    doReturn(mock(RequiredCache.class)).when(mockedDescription).getRequiredCache();
+    return mockedDescription;
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptBuilder.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptBuilder.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.webscript.mock;
+
+import org.springframework.extensions.webscripts.AbstractWebScript;
+
+public class MockWebscriptBuilder {
+  
+  static public MockWebscript singleWebscript(final AbstractWebScript webScript) {
+    return new MockWebscript(webScript);
+  }
+}

--- a/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptServletRequest.java
+++ b/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptServletRequest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright gradecak.com
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradecak.alfresco.mvc.webscript.mock;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+import org.springframework.extensions.webscripts.AbstractWebScript;
+import org.springframework.extensions.webscripts.Match;
+import org.springframework.extensions.webscripts.Runtime;
+import org.springframework.extensions.webscripts.servlet.WebScriptServletRequest;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+
+public class MockWebscriptServletRequest extends WebScriptServletRequest {
+
+  // private Content content;
+
+  private MockWebscriptServletRequest(Runtime mockedRuntime, MockHttpServletRequest mockHttpServletRequest, Match match) {
+    super(mockedRuntime, mockHttpServletRequest, match, null);
+  }
+
+  static public MockWebscriptServletRequest createMockWebscriptServletRequest(AbstractWebScript webScript, String method, String webscriptUrl, String controllerMapping,
+      final Map<String, String> parameters, final Map<String, String> body) {
+    Match match = new Match(null, ImmutableMap.of("", ""), webscriptUrl, webScript);
+    MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest(method, "http://localhost/alfresco" + webscriptUrl + controllerMapping);
+    mockHttpServletRequest.setServletPath("alfresco");
+    mockHttpServletRequest.setContextPath("http://localhost/");
+    mockHttpServletRequest.setContentType("application/json");
+    if (parameters != null) {
+      mockHttpServletRequest.setParameters(parameters);
+    }
+    try {
+      if (HttpMethod.POST.name().equals(method) && body != null) {
+        mockHttpServletRequest.setContent(new ObjectMapper().writeValueAsString(body).getBytes());
+      }
+    } catch (JsonProcessingException e) {
+      Throwables.propagate(e);
+    }
+
+    MockWebscriptServletRequest webscriptServletRequest = new MockWebscriptServletRequest(mock(Runtime.class), mockHttpServletRequest, match);
+    // if (content != null && !content.isEmpty()) {
+    // Content mockedContent = mock(Content.class);
+    // webscriptServletRequest.content = mockedContent;
+    // }
+
+    return webscriptServletRequest;
+  }
+}

--- a/src/test/resources/test-aop-context.xml
+++ b/src/test/resources/test-aop-context.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context" xmlns:mvc="http://www.springframework.org/schema/mvc"
+  xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
+  xsi:schemaLocation="
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <context:property-placeholder location="alfresco/module/mvc/alfresco-global.properties" />
+
+  <bean id="ServiceRegistry" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.alfresco.service.ServiceRegistry" />
+  </bean>
+
+  <import resource="classpath:alfresco/module/mvc/context/aop-context.xml" />
+
+  <bean id="test.autowiredProcessor" class="org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor" />
+
+  <context:component-scan base-package="com.gradecak.alfresco.mvc.service" annotation-config="false">
+    <context:include-filter expression="org.springframework.stereotype.Service" type="annotation" />
+  </context:component-scan>
+
+  <bean id="test.services" class="com.gradecak.alfresco.mvc.aop.PackageAutoProxyCreator">
+    <property name="basePackage" value="com.gradecak.alfresco.mvc.service" />
+  </bean>
+
+  <bean id="mvc.dispatcherWebscript" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="com.gradecak.alfresco.mvc.webscript.DispatcherWebscript" />
+  </bean>
+
+  <alias name="mvc.dispatcherWebscript" alias="webscript.alfresco-mvc.mvc.get" />
+
+</beans>

--- a/src/test/resources/test-webscriptdispatcher-context.xml
+++ b/src/test/resources/test-webscriptdispatcher-context.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context" xmlns:mvc="http://www.springframework.org/schema/mvc"
+  xmlns:aop="http://www.springframework.org/schema/aop" xmlns:tx="http://www.springframework.org/schema/tx"
+  xsi:schemaLocation="
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="flashMapManager" class="org.springframework.web.servlet.support.SessionFlashMapManager">
+  </bean>
+
+  <bean id="ServiceRegistry" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.alfresco.service.ServiceRegistry" />
+  </bean>
+  <!-- <bean class="org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter"> <property name="messageConverters">
+    <list> <bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter"> </bean> </list> </property>
+    </bean> -->
+
+  <mvc:annotation-driven />
+
+  <!-- <bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean"> <property name="converters">
+    <list> <bean class="com.gradecak.alfresco.mvc.jackson.Jackson2QnameSerializer" /> </list> </property> </bean> -->
+  <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
+    <!-- one of the properties available; the maximum file size in bytes -->
+    <property name="maxUploadSize" value="-1" />
+  </bean>
+
+  <context:component-scan base-package="com.gradecak.alfresco.mvc.controller">
+    <context:include-filter expression="org.springframework.stereotype.Controller" type="annotation" />
+  </context:component-scan>
+
+</beans>


### PR DESCRIPTION
Hi,

So, it's a similar idea to @jancalve pull request for https://github.com/dgradecak/alfresco-mvc/issues/4.

Configuration in repo is like this:

```
<!-- It needs to be a child of repositoryEndBootstrapBean so it only executed when the platform
       finishes bootstrapping -->
  <bean id="alfrescoMvcBean" class="com.gradecak.alfresco.mvc.bootstrap.MVCBootstrapper" parent="repositoryEndBootstrapBean">
    <property name="contextConfigLocation" value="classpath:alfresco/module/efiles-common-repo/context/servlet-context.xml" />
  </bean>

  <!-- mvc.dispatcherWebscript is defined in alfresco-mvc -->
  <alias name="mvc.dispatcherWebscript" alias="webscript.alfresco-mvc.mvc.get" />
  <alias name="mvc.dispatcherWebscript" alias="webscript.alfresco-mvc.mvc.post"/>
  <alias name="mvc.dispatcherWebscript" alias="webscript.alfresco-mvc.mvc.delete"/>
```

@dgradecak, we have you repository in our internal repository manager, so I modified just a couple of things, but I see that our code wasn't synchronized with your master at all, we are ahead. I couldn't find the correct branch and I find it strange that master is more out of date than your 4.5.0-SNAPSHOT tag. I would expect master to be up to date with the latest version.
The pull request I made includes the changes I have in our repository as well, so sorry if it has a lot of changes compared to your master.

Anyway, the only things I actually changed (at least concerning our repository) was
- com.gradecak.alfresco.mvc.bootstrap.MVCBootstrapper -> this is the new entrypoint for bootstrapping your library
- com.gradecak.alfresco.mvc.webscript.DispatcherWebscript -> This is just a webscript now, not the entrypoint
- aop-context.xml
- pom.xml
- README.md
and also the test DispatcherWebScriptTest, as a well as both test .xml resources.

I hope it helps.
