### PR TITLE
Adaptions for Alfresco Content Services 23.1.0

### DIFF
--- a/alfresco-mvc-aop/src/test/java/com/gradecak/alfresco/mvc/aop/TransactionalTest.java
+++ b/alfresco-mvc-aop/src/test/java/com/gradecak/alfresco/mvc/aop/TransactionalTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.transaction.SystemException;
+import jakarta.transaction.SystemException;
 
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;

--- a/alfresco-mvc-aop/src/test/java/com/gradecak/alfresco/mvc/service/TransactionalService.java
+++ b/alfresco-mvc-aop/src/test/java/com/gradecak/alfresco/mvc/service/TransactionalService.java
@@ -16,7 +16,7 @@
 
 package com.gradecak.alfresco.mvc.service;
 
-import javax.transaction.SystemException;
+import jakarta.transaction.SystemException;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.service.ServiceRegistry;

--- a/alfresco-mvc-rest/pom.xml
+++ b/alfresco-mvc-rest/pom.xml
@@ -17,8 +17,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/AlfrescoApiResponseInterceptor.java
+++ b/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/AlfrescoApiResponseInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.gradecak.alfresco.mvc.rest;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.alfresco.rest.framework.resource.parameters.Params;
 import org.alfresco.rest.framework.resource.parameters.Params.RecognizedParams;

--- a/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/annotation/AlfrescoDispatcherWebscript.java
+++ b/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/annotation/AlfrescoDispatcherWebscript.java
@@ -25,7 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpMethod;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.gradecak.alfresco.mvc.rest.config.AlfrescoRestRegistrar;
@@ -40,7 +40,7 @@ import com.gradecak.alfresco.mvc.webscript.DispatcherWebscript.ServletConfigOpti
 public @interface AlfrescoDispatcherWebscript {
 	String name() default "alfresco-mvc.mvc";
 
-	HttpMethod[] httpMethods() default { HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT };
+	RequestMethod[] httpMethods() default { RequestMethod.GET, RequestMethod.POST, RequestMethod.DELETE, RequestMethod.PUT };
 
 	Class<?> servletContext();
 

--- a/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/config/AlfrescoRestRegistrar.java
+++ b/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/config/AlfrescoRestRegistrar.java
@@ -27,6 +27,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.gradecak.alfresco.mvc.rest.annotation.AlfrescoDispatcherWebscript;
@@ -79,7 +80,7 @@ public class AlfrescoRestRegistrar implements ImportBeanDefinitionRegistrar {
 				.get("servletConfigOptions");
 		Class<? extends WebApplicationContext> servletContextClass = webscriptAttributes
 				.getClass("servletContextClass");
-		HttpMethod[] httpMethods = (HttpMethod[]) webscriptAttributes.get("httpMethods");
+		RequestMethod[] httpRequestMethods = (RequestMethod[]) webscriptAttributes.get("httpMethods");
 		boolean inheritGlobalProperties = (Boolean) webscriptAttributes.get("inheritGlobalProperties");
 
 		GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
@@ -94,8 +95,8 @@ public class AlfrescoRestRegistrar implements ImportBeanDefinitionRegistrar {
 
 		registry.registerBeanDefinition(webscript, beanDefinition);
 
-		for (HttpMethod httpMethod : httpMethods) {
-			registry.registerAlias(webscript, getWebscriptName(webscript, httpMethod));
+		for (RequestMethod httpRequestMethod : httpRequestMethods) {
+			registry.registerAlias(webscript, getWebscriptName(webscript, httpRequestMethod.asHttpMethod()));
 		}
 	}
 

--- a/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/config/DefaultAlfrescoMvcServletContextConfiguration.java
+++ b/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/rest/config/DefaultAlfrescoMvcServletContextConfiguration.java
@@ -39,7 +39,7 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.lang.Nullable;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.multipart.MultipartResolver;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -83,9 +83,7 @@ public class DefaultAlfrescoMvcServletContextConfiguration implements WebMvcConf
 	}
 
 	protected MultipartResolver createMultipartResolver() {
-		CommonsMultipartResolver resolver = new CommonsMultipartResolver();
-		resolver.setMaxUploadSize(-1);
-		resolver.setDefaultEncoding("utf-8");
+		StandardServletMultipartResolver resolver = new StandardServletMultipartResolver();
 		return resolver;
 	}
 

--- a/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscript.java
+++ b/alfresco-mvc-rest/src/main/java/com/gradecak/alfresco/mvc/webscript/DispatcherWebscript.java
@@ -29,11 +29,11 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/controller/TestController.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/controller/TestController.java
@@ -19,8 +19,8 @@ package com.gradecak.alfresco.mvc.controller;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithSuffixControllerTest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithSuffixControllerTest.java
@@ -74,7 +74,7 @@ public class WithSuffixControllerTest {
 				.getBean(DispatcherServlet.class);
 		Assertions.assertNotNull(dispatcherServlet);
 
-		MockHttpServletResponse res = mockWebscript.withControllerMapping("/test/withsufix.test").execute();
+		MockHttpServletResponse res = mockWebscript.withControllerMapping("test/withsufix.test").execute();
 		Assertions.assertEquals(HttpStatus.OK.value(), res.getStatus());
 
 		String contentAsString = res.getContentAsString();

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithoutSuffixControllerTest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithoutSuffixControllerTest.java
@@ -87,7 +87,7 @@ public class WithoutSuffixControllerTest {
 				.getBean(DispatcherServlet.class);
 		Assertions.assertNotNull(dispatcherServlet);
 
-		MockHttpServletResponse res = mockWebscript.withControllerMapping("/test/withoutsufix").execute();
+		MockHttpServletResponse res = mockWebscript.withControllerMapping("test/withoutsufix").execute();
 		Assertions.assertEquals(HttpStatus.OK.value(), res.getStatus());
 
 		String contentAsString = res.getContentAsString();

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/webscript/AlfrescoMvcRestTest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/webscript/AlfrescoMvcRestTest.java
@@ -24,7 +24,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 
 import org.alfresco.service.namespace.NamespaceService;
 import org.apache.commons.io.IOUtils;
@@ -187,7 +187,7 @@ public class AlfrescoMvcRestTest {
 		MockHttpServletResponse res = mockWebscript.withPostRequest().withParameters(ImmutableMap.of("id", "testId"))
 				.withControllerMapping("test/get").execute();
 		Assertions.assertEquals(res.getStatus(), HttpStatus.METHOD_NOT_ALLOWED.value());
-		Assertions.assertEquals("Request method 'POST' not supported", res.getErrorMessage());
+		Assertions.assertEquals("Method 'POST' is not supported.", res.getErrorMessage());
 	}
 
 	@Test

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscript.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscript.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Container;

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptServletRequest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/webscript/mock/MockWebscriptServletRequest.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Match;

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
 	</scm>
 
 	<properties>
-		<java.version>11</java.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.build.sourceVersion>11</maven.build.sourceVersion>
+		<java.version>17</java.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.build.sourceVersion>17</maven.build.sourceVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dependency.javax.servlet-api.version>4.0.1</dependency.javax.servlet-api.version>
+		<dependency.jakarta.servlet-api.version>6.0.0</dependency.jakarta.servlet-api.version>
 		<dependency.mockito.version>4.8.1</dependency.mockito.version>
 		<dependency.junit-jupiter.version>5.9.1</dependency.junit-jupiter.version>
 	</properties>
@@ -77,9 +77,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>${dependency.javax.servlet-api.version}</version>
+				<groupId>jakarta.servlet</groupId>
+				<artifactId>jakarta.servlet-api</artifactId>
+				<version>${dependency.jakarta.servlet-api.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -226,12 +226,19 @@
 
 		<profile>
 			<id>community-7.3.0</id>
+			<properties>
+				<dependency.acs-community-packaging.version>7.3.0</dependency.acs-community-packaging.version>
+				<dependency.spring-test.version>5.3.23</dependency.spring-test.version>
+			</properties>
+		</profile>
+		<profile>
+			<id>community-23.1.0</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
-				<dependency.acs-community-packaging.version>7.3.0</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.3.23</dependency.spring-test.version>
+				<dependency.acs-community-packaging.version>23.1.0</dependency.acs-community-packaging.version>
+				<dependency.spring-test.version>6.1.0</dependency.spring-test.version>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
Updated dependencies from javax.servlet to jakarta.servlet.
Adapted to some breaking changes in spring 6.